### PR TITLE
Tweak useCatalog query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Jetbrains IDEs
+.idea/
+
 # dependencies
 /node_modules
 /.pnp

--- a/src/helpers/catalog.js
+++ b/src/helpers/catalog.js
@@ -8,10 +8,9 @@ export const catalogQuery = `{
       id
       bookCode: header(id:"bookCode")
       h: header(id:"h")
-      toc1: header(id:"toc1")
+      toc: header(id:"toc")
       toc2: header(id:"toc2")
       toc3: header(id:"toc3")
-      mt: header(id:"mt")
     }
   }
 }`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10899,10 +10899,10 @@ proskomma-utils@^0.4.28:
     uuid-base64 "^1.0.0"
     xregexp "^4.4.1"
 
-proskomma@^0.6.2:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/proskomma/-/proskomma-0.6.3.tgz#379782aca0e3f3c7268ca8ae5f0a44c42e787f67"
-  integrity sha512-bTtJY3s58Iq+rfkz68sxU6DNV/phoWvvBtV2kJF93NKCVjQB6gP+5bZy9RYzZ+dCn3FDkmwN0qIdnuQzPyTknQ==
+proskomma@^0.6.4:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/proskomma/-/proskomma-0.6.8.tgz#efe37544e8afb8e22ee480697f94ad65e8199d59"
+  integrity sha512-xiWlrRjIdKr1FOxSB8Y7/LgH+dea1cnvSpewZAZKdLGxKXoxElJ5nrUG5fBcM/9YNfOVFr5oA4O6GdWDHxHbvg==
   dependencies:
     "@babel/core" "^7.12.9"
     async-mutex "^0.2.6"


### PR DESCRIPTION
There are two changes to the query:
1. Throughout Proskomma, trailing `1` is removed, so that there is never a need to handle, eg, both `q` and `q1`. By this logic, the `toc1` header becomes `toc`. Styleguidist now displays text for `toc` where, previously, `toc1` was null.
2. I removed `mt` because, within Proskomma, that's a title at the beginning of the content, rather than a header, ie this value will always be null within the headers.
I also added .idea/ to .gitignore to stop JetBrains IDEs like mine from committing the IDE files, and the version of Proskomma was bumped too.