### PR TITLE
useCatalog returns chapter and verse numbers; browserslist

### DIFF
--- a/src/helpers/catalog.js
+++ b/src/helpers/catalog.js
@@ -11,6 +11,13 @@ export const catalogQuery = `{
       toc: header(id:"toc")
       toc2: header(id:"toc2")
       toc3: header(id:"toc3")
+      cvNumbers: cvIndexes {
+        chapter
+        verses: verseNumbers {
+          number
+          range
+        }
+      }
     }
   }
 }`;

--- a/src/helpers/catalog.js
+++ b/src/helpers/catalog.js
@@ -1,7 +1,12 @@
 export const catalogQuery = `{
   nDocSets nDocuments
   docSets {
-    id hasMapping
+    id
+    selectors {
+      key
+      value
+    }
+    hasMapping
     documents (
       sortedBy: "paratext"
     ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,9 +3850,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001251, caniuse-lite@^1.0.30001254:
-  version "1.0.30001257"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz"
-  integrity sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
+  version "1.0.30001314"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz"
+  integrity sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I extended the GraphQL to return chapter and verse numbers for each document. This is quite cheap, and means that this one hook provides all the information needed to set up navigation. (Otherwise, you need another query which is less atomic.)

I also gave into browserslist nagging.