### PR TITLE
Remove includeContext from useSearchForPassages

### DIFF
--- a/src/helpers/searchForBookCodes.js
+++ b/src/helpers/searchForBookCodes.js
@@ -7,8 +7,7 @@ export const searchForBookCodesQuery = ({ text, docSetId }) => {
   const _searchTermsClause = searchTermsClause(text);
   const _attTermsClause = attTermsClause(text);
 
-  // TODO: figure out why this doesn't work with more than one book
-  const _sortClause = ''; // false ? `        sortedBy: "paratext"\n` : '';
+  const _sortClause = 'sortedBy: "paratext"';
 
   const bookCodeMatchQuery = `{
     docSet( id:"${docSetId}" ) {

--- a/src/helpers/searchForPassages.js
+++ b/src/helpers/searchForPassages.js
@@ -30,7 +30,7 @@ export const searchForPassagesQuery = ({
           withScopes: [${_attTermsClause}]
         ) {
           scopeLabels(startsWith:["chapter/", "verse/"])
-          itemGroups(byScopes:["chapter/", "verses/"], includeContext:true) {
+          itemGroups(byScopes:["chapter/", "verses/"]) {
             scopeLabels(startsWith:["verses/"])
             text
             ${_tokensClause}          }


### PR DESCRIPTION
I removed includeContext, which was crashing the query when blocks===true because I removed that option from Proskomma recently. I also put back the paratext sort option because I believe we fixed that issue in Proskomma.

I couldn't test this locally because of the import lockup thing.