### PR TITLE
Add tagsKv to useCatalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "proskomma": "^0.6.9",
+    "proskomma": "^0.6.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
@@ -63,7 +63,7 @@
     "lorem-ipsum-usfm": "^0.4.1",
     "prettier": "^2.5.1",
     "prop-types": "^15.7.2",
-    "proskomma": "^0.6.9",
+    "proskomma": "^0.6.10",
     "react": "^17.0.2",
     "react-docgen-external-proptypes-handler": "^2.0.0",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proskomma-react-hooks",
   "description": "A collection of React Hooks that provide a way to simplify the implementation of Proskomma into your React projects.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": false,
   "homepage": "https://proskomma-react-hooks.netlify.app/",
   "license": "MIT",

--- a/src/classes/uwProskomma.js
+++ b/src/classes/uwProskomma.js
@@ -18,7 +18,7 @@ class UWProskomma extends Proskomma {
       {
         name: 'abbr',
         type: 'string',
-        regex: '^[a-z0-9]+$',
+        regex: "^[A-za-z0-9_-]+$"
       },
     ];
     this.validateSelectors();

--- a/src/helpers/catalog.js
+++ b/src/helpers/catalog.js
@@ -2,10 +2,8 @@ export const catalogQuery = ({ cv }) => `{
   nDocSets nDocuments
   docSets {
     id
-    selectors {
-      key
-      value
-    }
+    tagsKv { key value }
+    selectors { key value }
     hasMapping
     documents (
       sortedBy: "paratext"
@@ -40,7 +38,16 @@ export const parseChapterVerseMapInDocSets = ({ docSets: _docSets }) => {
         selectors[key] = value;
       });
       docSet.selectors = selectors;
-    };
+    }
+
+    if (docSet?.tagsKv?.forEach) {
+      const tags = {};
+
+      docSet.tagsKv.forEach(({ key, value }) => {
+        tags[key] = value;
+      });
+      docSet.tagsKv = tags;
+    }
 
     docSet.documents.forEach((document) => {
       if (document?.cvNumbers) {
@@ -57,7 +64,7 @@ export const parseChapterVerseMapInDocSets = ({ docSets: _docSets }) => {
 
         delete document.cvNumbers;
         document.versesByChapters = chaptersVersesObject;
-      };
+      }
     });
   });
 

--- a/src/helpers/catalog.js
+++ b/src/helpers/catalog.js
@@ -46,7 +46,8 @@ export const parseChapterVerseMapInDocSets = ({ docSets: _docSets }) => {
       docSet.tagsKv.forEach(({ key, value }) => {
         tags[key] = value;
       });
-      docSet.tagsKv = tags;
+      delete document.tagsKv;
+      docSet.tags = tags;
     }
 
     docSet.documents.forEach((document) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10899,10 +10899,10 @@ proskomma-utils@^0.4.28:
     uuid-base64 "^1.0.0"
     xregexp "^4.4.1"
 
-proskomma@^0.6.9:
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/proskomma/-/proskomma-0.6.9.tgz#e2bb92ec3cd3f109c8d3068a780b8a4738ddc85f"
-  integrity sha512-/8wJyXrZb5107Ov2wIMEuFolZ3V0vROpUehPTYv3pSa8V0uqgItko00Sa8kt7yefS3LNc7PFrtqQOk7TZd815Q==
+proskomma@^0.6.10:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/proskomma/-/proskomma-0.6.10.tgz#d77b3f3c5b27e426e0baa975a8e2ede5c7dfb8dc"
+  integrity sha512-v0x4rei9CzJfXW9YYT9xITpNlfVgf0xotuiw+Ac+hqlXrkwXXZJz4J0g69EkzW91O9l10LJVVu9zCMg6T/uGDg==
   dependencies:
     "@babel/core" "^7.12.9"
     async-mutex "^0.2.6"


### PR DESCRIPTION
This PR leverages a minor update to Proskomma (0.6.10) which adds a `tagsKv` endpoint. This endpoint treats tags as serialized key/value tuples and returns an array of `keyValue` tuples in a similar way to docSet `selectors`. The use case for this is to shoehorn metadata such as copyright into Proskomma in an unopinionated (ie 'waiting for Scripture Burrito') way.

The endpoint shows up in Styleguidist. For the `catalog` endpoint I turn the array of tuples into an object using the same logic as for `selectors`. The array and object are empty because adding tags means significant changes to the test setup. The `tagsKv` functionality is tested in Proskomma. It is also used by Diegesis Server where the value of that endpoint in one test scenario is
```
[
  'title:Louis Segond 1910',
  'copyright:public domain',
  'direction:ltr',
  'script:Latin'
]
```
which, at the `catalog` endpoint, would become
```
{
  "title": "Louis Segond 1910",
  "copyright": "public domain",
  "direction" :"ltr",
  "script": "Latin"
}
```
(For tags with no colon, this representation assigns an empty string as the value. The older `tags` endpoint still works and makes more sense when treating tags as atomic flags.)

This should be a non-breaking change.